### PR TITLE
2 changes: try to prevent runaway recursive calls to on_destruct, and…

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -82,8 +82,15 @@ vines.register_vine = function( name, defs, biome )
       local node = minetest.get_node( pos )
       local bottom = {x=pos.x, y=pos.y-1, z=pos.z}
       local bottom_node = minetest.get_node( bottom )
-      if minetest.get_item_group( bottom_node.name, "vines") then
-        minetest.remove_node( bottom )
+
+      -- get_item_group seems to be the right way to check the nature
+      -- of the node below us, but that function may have a bug that
+      -- causes out-of-memory crashes
+      --if minetest.get_item_group( bottom_node.name, "vines") then
+      if bottom_node.name == vine_name_middle or bottom_node.name == vine_name_end then
+        -- using "return" here causes Lua to use tail-call optimization,
+        -- reducing memory load of recursive calls
+        return minetest.remove_node( bottom )
       end
     end,
     after_dig_node = function( pos, node, oldmetadata, user )
@@ -94,7 +101,7 @@ vines.register_vine = function( name, defs, biome )
   biome_lib:spawn_on_surfaces( biome )
 
   local override_nodes = function( nodes, defs )
-  local function override( index, registered )
+    local function override( index, registered )
       local node = nodes[ index ]
       if index > #nodes then return registered end
       if minetest.registered_nodes[node] then
@@ -130,3 +137,4 @@ vines.dig_vine = function( pos, node_name, user )
     end
   end
 end
+


### PR DESCRIPTION
… make the recursions less memory-intensive

My Minetest server was crashing when people dug vines. The issue seems to be related to either 1) really really long vines on the map (not necessarily the ones being dug), or 2) digging a vine that's in a door's airspace. Once triggered, some recursive feedback loop would happen that would rapidly eat up all available memory and cause Minetest to crash with an out-of-memory error.

The error centered around the `on_destruct` function of the `vine_name_middle` node. Experimentation revealed two solutions: 1) putting `return` in front of `minetest.remove_node( bottom )` to make Lua use tail-call optimization for recursive function calls (https://github.com/minetest/minetest/issues/4793#issuecomment-261686625), and 2) replacing the call to `get_item_group` with a couple of simple name checks for the node (i.e. check whether the node below is one of the two vine nodes, namely `vine_name_middle` or `vine_name_end`). Both these solutions work on their own; it's clear why the first one helps but not so clear why the second one does. My current speculation is that the first solution is still experiencing the runaway recursion, but by using the tail-call optimization the memory hit from that is manageable; while I think the second avoids the runaway recursion altogether.

Thus I opted to use both, in hopes of maximally reducing the memory hit of the vines mod. The small price to pay for this is a slightly less robust check for whether the node below is a vine--if a new vine node gets added in the future to the "vines" group, it won't be automatically captured by the proposed check