### PR TITLE
Prevent two separate instances of stack overflow.

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -61,7 +61,6 @@ vines.register_vine = function( name, defs, biome )
     end
   })
 
-
   minetest.register_node( vine_name_middle, {
     description = "Matured "..defs.description,
     walkable = false,
@@ -83,7 +82,7 @@ vines.register_vine = function( name, defs, biome )
       local bottom = {x=pos.x, y=pos.y-1, z=pos.z}
       local bottom_node = minetest.get_node( bottom )
       if minetest.get_item_group( bottom_node.name, "vines") then
-        minetest.remove_node( bottom )
+        minetest.after( 0, minetest.remove_node, bottom )
       end
     end,
     after_dig_node = function( pos, node, oldmetadata, user )


### PR DESCRIPTION
The first one happens because `remove_node` is called directly, calling `remove_node` for the vine below,
calling `remove_node` for the vine below, calling...

The second one happens because `get_item_group` returns 0 for groups not set, and 0 is a truthy
value in Lua, so the code always removes the bottom node regardless of its group rating. This interacted
funnily with doors wanting to remove their top node, while vines wanted to remove their bottom nodes.

Tries to fix the issue mentioned in #7.

Ported from minetest-mods/plantlife_modpack@d85fb4c64f5f1305d62370e7dafcfb6e0a1a0f69.