### PR TITLE
Add `.luacheckrc` and fix warnings.

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,13 @@
+
+unused_args = false
+
+read_globals = {
+	"minetest",
+	"default",
+	"ItemStack",
+	"biome_lib",
+}
+
+globals = {
+	"vines",
+}

--- a/functions.lua
+++ b/functions.lua
@@ -1,5 +1,4 @@
 vines.register_vine = function( name, defs, biome )
-  local biome = biome
   local groups = { vines=1, snappy=3, flammable=2 }
 
   local vine_name_end = 'vines:'..name..'_end'
@@ -79,7 +78,6 @@ vines.register_vine = function( name, defs, biome )
     sounds = default.node_sound_leaves_defaults(),
     selection_box = selection_box,
     on_destruct = function( pos )
-      local node = minetest.get_node( pos )
       local bottom = {x=pos.x, y=pos.y-1, z=pos.z}
       local bottom_node = minetest.get_node( bottom )
       if minetest.get_item_group( bottom_node.name, "vines") then
@@ -93,12 +91,12 @@ vines.register_vine = function( name, defs, biome )
 
   biome_lib:spawn_on_surfaces( biome )
 
-  local override_nodes = function( nodes, defs )
+  local override_nodes = function( nodes, def )
   local function override( index, registered )
       local node = nodes[ index ]
       if index > #nodes then return registered end
       if minetest.registered_nodes[node] then
-        minetest.override_item( node, defs )
+        minetest.override_item( node, def )
         registered[#registered+1] = node
       end
       override( index+1, registered )
@@ -123,7 +121,7 @@ vines.dig_vine = function( pos, node_name, user )
   --only dig give the vine if shears are used
   if not user then return false end
   local wielded = user:get_wielded_item()
-  if 'vines:shears' == wielded:get_name() then 
+  if 'vines:shears' == wielded:get_name() then
     local inv = user:get_inventory()
     if inv then
       inv:add_item("main", ItemStack( node_name ))

--- a/nodes.lua
+++ b/nodes.lua
@@ -58,7 +58,7 @@ minetest.register_node("vines:rope_end", {
   groups = {flammable=2, not_in_creative_inventory=1},
   sounds =  default.node_sound_leaves_defaults(),
   after_place_node = function(pos)
-    yesh  = {x = pos.x, y= pos.y-1, z=pos.z}
+    local yesh  = {x = pos.x, y= pos.y-1, z=pos.z}
     minetest.add_node(yesh, {name="vines:rope"})
   end,
   selection_box = {

--- a/vines.lua
+++ b/vines.lua
@@ -43,7 +43,6 @@ vines.register_vine( 'side', {
 },{
   choose_random_wall = true,
   avoid_nodes = {"group:vines", "default:apple"},
-  choose_random_wall = true,
   avoid_radius = 3,
   spawn_delay = 500,
   spawn_chance = 100,


### PR DESCRIPTION
```
Checking functions.lua                            4 warnings

    functions.lua:2:9: variable 'biome' was previously defined as an argument on line 1
    functions.lua:81:13: unused variable 'node'
    functions.lua:97:43: shadowing upvalue argument 'defs' on line 1
    functions.lua:127:47: line contains trailing whitespace

Checking nodes.lua                                2 warnings

    nodes.lua:61:5: setting non-standard global variable 'yesh'
    nodes.lua:62:23: accessing undefined variable 'yesh'

Checking vines.lua                                1 warning

    vines.lua:44:3: value assigned to field 'choose_random_wall' is unused

Total: 7 warnings / 0 errors in 8 files
```